### PR TITLE
Add eslint config for preact

### DIFF
--- a/packages/eslint-config-migme/preact.js
+++ b/packages/eslint-config-migme/preact.js
@@ -1,0 +1,8 @@
+module.exports = {
+  extends: [
+    './base',
+    './rules/strict',
+    './rules/preact',
+  ].map(require.resolve),
+  rules: {},
+}

--- a/packages/eslint-config-migme/rules/preact.js
+++ b/packages/eslint-config-migme/rules/preact.js
@@ -1,0 +1,87 @@
+module.exports = {
+  plugins: [
+    'react',
+  ],
+  "settings": {
+    "react": {
+      "createClass": "h", // Regex for Component Factory to use, default to "createClass"
+      "pragma": "preact",  // Pragma to use, default to "React"
+      "version": "15.0" // React version, default to the latest React stable release
+    }
+  },
+  ecmaFeatures: {
+    jsx: true,
+  },
+  rules: {
+    'react/display-name': [0, { ignoreTranspilerName: false }],
+    'react/forbid-prop-types': [0, { forbid: ['any', 'array', 'object'] }],
+    'react/jsx-boolean-value': [2, 'never'],
+    'react/jsx-closing-bracket-location': [2, 'line-aligned'],
+    'react/jsx-curly-spacing': [0, 'never', { allowMultiline: true }],
+    'react/jsx-handler-names': [0, {
+      eventHandlerPrefix: 'handle',
+      eventHandlerPropPrefix: 'on',
+    }],
+    'react/jsx-indent-props': [2, 2],
+    'react/jsx-indent': [2, 2],
+    'react/jsx-key': 0,
+    'react/jsx-max-props-per-line': [0, { maximum: 1 }],
+    'react/jsx-no-bind': [2, {
+      ignoreRefs: false,
+      allowArrowFunctions: true,
+      allowBind: false,
+    }],
+    'react/jsx-no-duplicate-props': [0, { ignoreCase: false }],
+    'react/jsx-no-literals': 0,
+    'react/jsx-no-undef': 2,
+    'react/jsx-pascal-case': 0,
+    'react/jsx-sort-props': [0, {
+      ignoreCase: false,
+      callbacksLast: true,
+      shorthandFirst: true,
+    }],
+    'react/jsx-space-before-closing': [2, 'always'],
+    'react/jsx-uses-react': 2,
+    'react/jsx-uses-vars': 2,
+    'react/no-danger': 0,
+    'react/no-deprecated': [1, { react: '0.14.0' }],
+    'react/no-did-mount-set-state': [2, 'allow-in-func'],
+    'react/no-did-update-set-state': [2, 'allow-in-func'],
+    'react/no-direct-mutation-state': 0,
+    'react/no-is-mounted': 2,
+    'react/no-multi-comp': [2, { ignoreStateless: true }],
+    'react/no-set-state': 0,
+    'react/no-string-refs': 0,
+    'react/no-unknown-property': 2,
+    'react/prefer-es6-class': [2, 'always'],
+    'react/prefer-stateless-function': 2,
+    'react/prop-types': [2, {
+      ignore: [],
+      customValidators: [],
+    }],
+    'react/react-in-jsx-scope': 2,
+    'react/require-extension': [0, { extensions: ['.jsx'] }],
+    'react/self-closing-comp': 2,
+    'react/sort-comp': [2, {
+      order: [
+        'static-methods',
+        'lifecycle',
+        '/^on.+$/',
+        '/^(get|set)(?!(InitialState$|DefaultProps$|ChildContext$)).+$/',
+        'everything-else',
+        '/^render.+$/',
+        'render',
+      ],
+    }],
+    'react/sort-prop-types': [2, {
+      ignoreCase: false,
+      callbacksLast: true,
+      requiredFirst: true,
+    }],
+    'react/wrap-multilines': [2, {
+      declaration: true,
+      assignment: true,
+      return: true,
+    }],
+  },
+}

--- a/packages/eslint-config-migme/rules/preact.js
+++ b/packages/eslint-config-migme/rules/preact.js
@@ -1,87 +1,11 @@
-module.exports = {
-  plugins: [
-    'react',
-  ],
-  "settings": {
-    "react": {
-      "createClass": "h", // Regex for Component Factory to use, default to "createClass"
-      "pragma": "preact",  // Pragma to use, default to "React"
-      "version": "15.0" // React version, default to the latest React stable release
-    }
-  },
-  ecmaFeatures: {
-    jsx: true,
-  },
-  rules: {
-    'react/display-name': [0, { ignoreTranspilerName: false }],
-    'react/forbid-prop-types': [0, { forbid: ['any', 'array', 'object'] }],
-    'react/jsx-boolean-value': [2, 'never'],
-    'react/jsx-closing-bracket-location': [2, 'line-aligned'],
-    'react/jsx-curly-spacing': [0, 'never', { allowMultiline: true }],
-    'react/jsx-handler-names': [0, {
-      eventHandlerPrefix: 'handle',
-      eventHandlerPropPrefix: 'on',
-    }],
-    'react/jsx-indent-props': [2, 2],
-    'react/jsx-indent': [2, 2],
-    'react/jsx-key': 0,
-    'react/jsx-max-props-per-line': [0, { maximum: 1 }],
-    'react/jsx-no-bind': [2, {
-      ignoreRefs: false,
-      allowArrowFunctions: true,
-      allowBind: false,
-    }],
-    'react/jsx-no-duplicate-props': [0, { ignoreCase: false }],
-    'react/jsx-no-literals': 0,
-    'react/jsx-no-undef': 2,
-    'react/jsx-pascal-case': 0,
-    'react/jsx-sort-props': [0, {
-      ignoreCase: false,
-      callbacksLast: true,
-      shorthandFirst: true,
-    }],
-    'react/jsx-space-before-closing': [2, 'always'],
-    'react/jsx-uses-react': 2,
-    'react/jsx-uses-vars': 2,
-    'react/no-danger': 0,
-    'react/no-deprecated': [1, { react: '0.14.0' }],
-    'react/no-did-mount-set-state': [2, 'allow-in-func'],
-    'react/no-did-update-set-state': [2, 'allow-in-func'],
-    'react/no-direct-mutation-state': 0,
-    'react/no-is-mounted': 2,
-    'react/no-multi-comp': [2, { ignoreStateless: true }],
-    'react/no-set-state': 0,
-    'react/no-string-refs': 0,
-    'react/no-unknown-property': 2,
-    'react/prefer-es6-class': [2, 'always'],
-    'react/prefer-stateless-function': 2,
-    'react/prop-types': [2, {
-      ignore: [],
-      customValidators: [],
-    }],
-    'react/react-in-jsx-scope': 2,
-    'react/require-extension': [0, { extensions: ['.jsx'] }],
-    'react/self-closing-comp': 2,
-    'react/sort-comp': [2, {
-      order: [
-        'static-methods',
-        'lifecycle',
-        '/^on.+$/',
-        '/^(get|set)(?!(InitialState$|DefaultProps$|ChildContext$)).+$/',
-        'everything-else',
-        '/^render.+$/',
-        'render',
-      ],
-    }],
-    'react/sort-prop-types': [2, {
-      ignoreCase: false,
-      callbacksLast: true,
-      requiredFirst: true,
-    }],
-    'react/wrap-multilines': [2, {
-      declaration: true,
-      assignment: true,
-      return: true,
-    }],
-  },
+const preactRules = Object.assign({}, require('./react'))
+
+preactRules['settings'] = {
+  "react": {
+    "createClass": "h", // Regex for Component Factory to use, default to "createClass"
+    "pragma": "preact",  // Pragma to use, default to "React"
+    "version": "15.0" // React version, default to the latest React stable release
+  }
 }
+
+module.exports = preactRules

--- a/packages/eslint-config-migme/rules/react.js
+++ b/packages/eslint-config-migme/rules/react.js
@@ -34,7 +34,7 @@ module.exports = {
       shorthandFirst: true,
     }],
     'react/jsx-space-before-closing': [2, 'always'],
-    'react/jsx-uses-react': [2, { pragma: 'React' }],
+    'react/jsx-uses-react': 2,
     'react/jsx-uses-vars': 2,
     'react/no-danger': 0,
     'react/no-deprecated': [1, { react: '0.14.0' }],


### PR DESCRIPTION
Create [preact rules](https://github.com/migme/javascript/blob/ac7f3f19e4ac50e9584f82e0d0d8c26fed965391/packages/eslint-config-migme/rules/preact.js) based on [react rules](https://github.com/migme/javascript/blob/master/packages/eslint-config-migme/rules/react.js)

The difference is that it checks `preact` instead of `react`. Meaning that in a JS/JSX file containing JSX, it is required `import 'preact'` being there.

In preact project, we can use this setting in `.eslintrc` to use it:

```
{
  "extends": "migme/preact"
}
```
